### PR TITLE
setup.py: Use a PEP440-compatible `version=`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pypodio2",
-    version="everlaw.0.2.1",
+    version="0.2.1+everlaw1",
     description="Python wrapper for the Podio API",
     author="Podio",
     author_email="mail@podio.com",


### PR DESCRIPTION
Without this change, we see warnings like

    $ pip install .
    Processing /home/kevinmurphy/src/everlaw/podio-py
      Preparing metadata (setup.py) ... done
    Requirement already satisfied: httplib2 in ./venv/lib/python3.8/site-packages (from pypodio2===everlaw.0.2.1) (0.20.4)
    Requirement already satisfied: pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 in ./venv/lib/python3.8/site-packages (from httplib2->pypodio2===everlaw.0.2.1) (3.0.9)
    Building wheels for collected packages: pypodio2
      Building wheel for pypodio2 (setup.py) ... done
      Created wheel for pypodio2: filename=pypodio2-everlaw.0.2.1-py3-none-any.whl size=14150 sha256=e7b3da92ac9a0043aa25a0350ab1b2086d36992283610c8e1c35b114f69f898a
      Stored in directory: /home/kevinmurphy/.cache/pip/wheels/2f/f5/9e/b2aaaa0a0c0d6bd17f2999e538d23c054bd9606a074cd844ec
      WARNING: Built wheel for pypodio2 is invalid: Metadata 1.2 mandates PEP 440 version, but 'everlaw.0.2.1' is not
    Failed to build pypodio2
    Installing collected packages: pypodio2
      Attempting uninstall: pypodio2
        Found existing installation: pypodio2 everlaw.0.2.1
        Uninstalling pypodio2-everlaw.0.2.1:
          Successfully uninstalled pypodio2-everlaw.0.2.1
      Running setup.py install for pypodio2 ... done
      DEPRECATION: pypodio2 was installed using the legacy 'setup.py install' method, because a wheel could not be built for it. A possible replacement is to fix the wheel build issue reported above. Discussion can be found at https://github.com/pypa/pip/issues/8368
    Successfully installed pypodio2-everlaw.0.2.1

Ultimately, this leaves us with a broken installation.

See https://peps.python.org/pep-0440/#local-version-identifiers