### PR TITLE
transport.py: Don't disable SSL cert validation

### DIFF
--- a/pypodio2/transport.py
+++ b/pypodio2/transport.py
@@ -38,7 +38,7 @@ class OAuthAuthorizationBase(object):
         self.domain = domain
 
     def token_request(self, body):
-        h = Http(disable_ssl_certificate_validation=True)
+        h = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(self.domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
@@ -125,7 +125,7 @@ class HttpTransport(object):
         self._attribute_stack = []
         self._method = "GET"
         self._posts = []
-        self._http = Http(disable_ssl_certificate_validation=True)
+        self._http = Http()
         self._params = {}
         self._url_template = '%(domain)s/%(generated_url)s'
         self._stack_collapser = "/".join

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pypodio2",
-    version="0.2.1+everlaw1",
+    version="0.2.1+everlaw2rc1",
     description="Python wrapper for the Podio API",
     author="Podio",
     author_email="mail@podio.com",


### PR DESCRIPTION
This is basically cherry-picks https://github.com/podio/podio-py/pull/40.

Original commit message from @gmcguire:

> Allow normal SSL certificate checking
>
> This fixes issue #27. As far as I can tell api.podio.com has a perfectly valid SSL certificate.

Closes https://podio.com/easyesicom/feature-roadmap/apps/bugs/items/22339